### PR TITLE
Improve map

### DIFF
--- a/app.json
+++ b/app.json
@@ -15,6 +15,11 @@
       "**/*"
     ],
     "ios": {
+      "infoPlist": {
+        "NSLocationWhenInUseUsageDescription": "This app needs access to share location with group members.",
+        "NSLocationAlwaysAndWhenInUseUsageDescription": "This app needs access to share location with group members.",
+        "NSLocationAlwaysUsageDescription": "This app needs access to share location with group members."
+      },
       "supportsTablet": true
     },
     "android": {

--- a/app/_layout.js
+++ b/app/_layout.js
@@ -3,14 +3,17 @@ import { Alert, Button, TextInput, View, StyleSheet, ActivityIndicator } from 'r
 import { Slot } from 'expo-router';
 import { AppStateProvider } from '../contexts/AppState';
 import { RouterProvider } from '../contexts/RouterContext';
+import { LocationShareProvider } from '../contexts/LocationShareContext';
 
 export default function App() {
     return (
         <AppStateProvider>
             <RouterProvider>
-                <View style={styles.container}>
-                    <Slot/>
-                </View>
+                <LocationShareProvider>
+                    <View style={styles.container}>
+                        <Slot/>
+                    </View>
+                </LocationShareProvider>
             </RouterProvider>
         </AppStateProvider>
     );

--- a/app/map.js
+++ b/app/map.js
@@ -8,6 +8,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { Entypo } from '@expo/vector-icons';
 import { Feather } from '@expo/vector-icons';
 import { AppStateContext } from '../contexts/AppState';
+import { LocationShareContext } from '../contexts/LocationShareContext';
 import * as SecureStore from 'expo-secure-store';
 import jwtDecode from 'jwt-decode';
 
@@ -17,6 +18,15 @@ export default function Map() {
   const [sharedLocations, setSharedLocations] = useState({}); // state for shared locations
   const mapRef = useRef(); // create a ref so that map doesn't re-render on zoom
   const [username, setUsername] = useState(null);
+  const { isLocationSharingEnabled, startLocationSharing, stopLocationSharing } = useContext(LocationShareContext);
+
+  const handleLocationSharing = () => {
+    if (isLocationSharingEnabled) {
+      stopLocationSharing();
+    } else {
+      startLocationSharing(socket);
+    }
+  };
 
   useEffect(() => {
     (async () => {
@@ -33,11 +43,9 @@ export default function Map() {
         return;
       }
 
+      // set location to user's location - used to center map and to display marker if 
       let location = await Location.getCurrentPositionAsync({});
       setLocation(location);
-      console.log("Sending location to server:", { location });
-      
-      socket.emit('shareLocation', location);
 
       // Listen for socket events
       socket.on('updateLocations', locationData => {
@@ -117,6 +125,11 @@ export default function Map() {
             </Pressable>
           )}
         </View>
+        <Pressable onPress={handleLocationSharing}>
+          {isLocationSharingEnabled
+          ? <Text style={{color: "green"}}>Location Sharing On</Text>
+          : <Text style={{color: "grey"}}>Location Sharing Off</Text>}
+        </Pressable>
         <Link href="/group" asChild>
           <Ionicons name="people-circle-outline" size={36} color="#23A7E0" />      
         </Link>

--- a/contexts/LocationShareContext.js
+++ b/contexts/LocationShareContext.js
@@ -1,0 +1,34 @@
+import React, { createContext, useState, useEffect, useContext } from 'react';
+import { startLocationUpdates, stopLocationUpdates } from '../services/LocationService';
+import { AppStateContext } from '../contexts/AppState';
+
+export const LocationShareContext = createContext();
+
+export const LocationShareProvider = ({ children }) => {
+  const { socket } = useContext(AppStateContext);
+  const [isLocationSharingEnabled, setIsLocationSharingEnabled] = useState(false); // default to false
+
+  const startLocationSharing = () => {
+    startLocationUpdates(socket);
+    setIsLocationSharingEnabled(true);
+  };
+
+  const stopLocationSharing = () => {
+    stopLocationUpdates();
+    setIsLocationSharingEnabled(false);
+  };
+
+  useEffect(() => {
+    if (isLocationSharingEnabled) {
+      startLocationSharing();
+    } else {
+      stopLocationSharing();
+    }
+  }, [isLocationSharingEnabled, socket]);
+
+  return (
+    <LocationShareContext.Provider value={{ isLocationSharingEnabled, startLocationSharing, stopLocationSharing }}>
+      {children}
+    </LocationShareContext.Provider>
+  );
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "expo-router": "^2.0.0",
         "expo-secure-store": "~12.3.1",
         "expo-status-bar": "~1.6.0",
+        "geolib": "^3.3.4",
         "jwt-decode": "^3.1.2",
         "react": "18.2.0",
         "react-dom": "18.2.0",
@@ -8543,6 +8544,11 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/geolib": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/geolib/-/geolib-3.3.4.tgz",
+      "integrity": "sha512-EicrlLLL3S42gE9/wde+11uiaYAaeSVDwCUIv2uMIoRBfNJCn8EsSI+6nS3r4TCKDO6+RQNM9ayLq2at+oZQWQ=="
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "expo-router": "^2.0.0",
     "expo-secure-store": "~12.3.1",
     "expo-status-bar": "~1.6.0",
+    "expo-task-manager": "~11.3.0",
+    "geolib": "^3.3.4",
     "jwt-decode": "^3.1.2",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/services/LocationService.js
+++ b/services/LocationService.js
@@ -1,8 +1,7 @@
 import * as Location from 'expo-location';
-import * as TaskManager from 'expo-task-manager';
+// import * as TaskManager from 'expo-task-manager';
 import { getDistance } from 'geolib';
 
-const LOCATION_UPDATE_TASK_NAME = 'background-location-update';
 const UPDATE_INTERVAL_IN_MS = 5 * 60 * 1000; // send location regardless of movement this often, currently 5 mins
 const UPDATE_DISTANCE_IN_M = 2; // distance moved that will trigger shareLocation event in meters
 
@@ -11,6 +10,8 @@ let lastTimeSent = null;
 let socket = null;
 
 /* Location.requestBackgroundPermissionAsync() NOT SUPPORTED BY EXPO GO LAB ENVIRONMENT
+
+const LOCATION_UPDATE_TASK_NAME = 'background-location-update';
 
 // Define the task that will be run in the background
 TaskManager.defineTask(LOCATION_UPDATE_TASK_NAME, ({ data: { locations }, error }) => {

--- a/services/LocationService.js
+++ b/services/LocationService.js
@@ -1,0 +1,104 @@
+import * as Location from 'expo-location';
+import * as TaskManager from 'expo-task-manager';
+import { getDistance } from 'geolib';
+
+const LOCATION_UPDATE_TASK_NAME = 'background-location-update';
+const UPDATE_INTERVAL_IN_MS = 5 * 60 * 1000; // send location regardless of movement this often, currently 5 mins
+const UPDATE_DISTANCE_IN_M = 2; // distance moved that will trigger shareLocation event in meters
+
+let lastLocationSent = null;
+let lastTimeSent = null;
+let socket = null;
+
+/* Location.requestBackgroundPermissionAsync() NOT SUPPORTED BY EXPO GO LAB ENVIRONMENT
+
+// Define the task that will be run in the background
+TaskManager.defineTask(LOCATION_UPDATE_TASK_NAME, ({ data: { locations }, error }) => {
+  if (error) {
+    // check `error.message` for the error message
+    return;
+  }
+
+  const newLocation = locations[0];
+
+  // If AUTO_UPDATE_INTERVAL has passed since last shareLocation socket event or user has moved more than UPDATE_DISTANCE_IN_M
+  if (
+    (!lastTimeSent || new Date() - lastTimeSent >= UPDATE_INTERVAL_IN_MS) ||
+    (!lastLocationSent || getDistance(newLocation.coords, lastLocationSent.coords) >= UPDATE_DISTANCE_IN_M)
+  ) {
+    console.log('Sending location to server:', newLocation);
+    socket.emit('shareLocation', newLocation);
+    lastLocationSent = newLocation;
+    lastTimeSent = new Date();
+  }
+});
+
+async function startLocationUpdates(newSocket) {
+  const { status } = await Location.requestBackgroundPermissionAsync();
+  if (status === 'granted') {
+    socket = newSocket;
+    await Location.startLocationUpdatesAsync(LOCATION_UPDATE_TASK_NAME, {
+      accuracy: Location.Accuracy.BestForNavigation,
+      timeInterval: 5000,  // Update every 5 seconds
+    });
+  }
+}
+
+async function startLocationUpdates(newSocket) {
+  const { status } = await Location.requestForegroundPermissionsAsync();
+  if (status === 'granted') {
+    socket = newSocket;
+    await Location.watchPositionAsync(
+      {
+        accuracy: Location.Accuracy.BestForNavigation,
+        timeInterval: 5000,  // Update every 5 seconds
+      }
+    );
+  }
+}
+
+async function stopLocationUpdates() {
+  try {
+    await Location.stopLocationUpdatesAsync(LOCATION_UPDATE_TASK_NAME);
+  } catch (error) {
+    console.log(`Failed to stop location updates: ${error.message}`);
+  }
+}
+
+*/
+
+let locationSubscription;
+
+async function startLocationUpdates(newSocket) {
+  const { status } = await Location.requestForegroundPermissionsAsync();
+  if (status === 'granted') {
+    socket = newSocket;
+    locationSubscription = await Location.watchPositionAsync(
+      {
+        accuracy: Location.Accuracy.BestForNavigation,
+        timeInterval: 5000,  // Update every 5 seconds
+      }, 
+      (location) => {
+        // Check if AUTO_UPDATE_INTERVAL has passed since the last shareLocation socket event
+        // or if the user has moved more than UPDATE_DISTANCE_IN_M
+        if (
+          (!lastTimeSent || new Date() - lastTimeSent >= UPDATE_INTERVAL_IN_MS) ||
+          (!lastLocationSent || getDistance(location.coords, lastLocationSent.coords) >= UPDATE_DISTANCE_IN_M)
+        ) {
+          console.log('Sending location to server:', location);
+          socket.emit('shareLocation', location);
+          lastLocationSent = location;
+          lastTimeSent = new Date();
+        }
+      }
+    );
+  }
+}
+
+async function stopLocationUpdates() {
+  if (locationSubscription) {
+    locationSubscription.remove();
+  }
+}
+
+export { startLocationUpdates, stopLocationUpdates };


### PR DESCRIPTION
app/map.js - Added a toggle button to the UI that toggles the LocationShareContext value, so location sharing is no longer on by default. Also updated the map so that 

Added two new files:

contexts/LocationShareContext: this houses the self-titled LocationShareContext so that all views can access whether location sharing is currently enabled. It is also calls two methods from LocationService that handle the location socket events.

services/LocationService.js - Contains methods to start and stop location sharing.

app/_layout.js - Added the LocationShareProvider to the component tree

app.json: Added infoPlist values, which I later learned are unnecessary for Expo Go because it does not support background location sharing.